### PR TITLE
Trigger dags on startup

### DIFF
--- a/clear-missing-dags/airflow-clear-missing-dags.py
+++ b/clear-missing-dags/airflow-clear-missing-dags.py
@@ -1,8 +1,8 @@
 """
-A maintenance workflow that you can deploy into Airflow to periodically clean out entries in the DAG table of which there is no longer a corresponding Python File for it. This ensures that the DAG table doesn't have needless items in it and that the Airflow Web Server displays only those available DAGs.
-
-airflow trigger_dag airflow-clear-missing-dags
-
+A maintenance workflow that you can deploy into Airflow to periodically clean
+out entries in the DAG table of which there is no longer a corresponding Python
+File for it. This ensures that the DAG table doesn't have needless items in it
+and that the Airflow Web Server displays only those available DAGs.
 """
 from datetime import datetime, timedelta
 import os
@@ -16,15 +16,15 @@ from airflow import settings
 
 DAG_ID = os.path.basename(__file__).replace(".pyc", "").replace(".py", "")  # airflow-clear-missing-dags
 START_DATE = datetime.now() - timedelta(minutes=1)
-SCHEDULE_INTERVAL = "@daily"        # How often to Run. @daily - Once a day at Midnight
-DAG_OWNER_NAME = "operations"       # Who is listed as the owner of this DAG in the Airflow Web Server
-ALERT_EMAIL_ADDRESSES = []          # List of email address to send email alerts to if this job fails
-ENABLE_DELETE = True                # Whether the job should delete the logs or not. Included if you want to temporarily avoid deleting the logs
+SCHEDULE_INTERVAL = timedelta(days=1)  # How often to Run. @daily - Once a day at Midnight
+DAG_OWNER_NAME = "operations"          # Who is listed as the owner of this DAG in the Airflow Web Server
+ALERT_EMAIL_ADDRESSES = []             # List of email address to send email alerts to if this job fails
+ENABLE_DELETE = True                   # Whether the job should delete the logs or not. Included if you want to temporarily avoid deleting the logs
 
 default_args = {
     'owner': DAG_OWNER_NAME,
     'email': ALERT_EMAIL_ADDRESSES,
-    'email_on_failure': True,
+    'email_on_failure': False,
     'email_on_retry': False,
     'start_date': START_DATE,
     'retries': 1,
@@ -84,7 +84,7 @@ def clear_missing_dags_fn(**context):
             session.delete(entry)
         logging.info("Finished Performing Delete")
     else:
-        logging.warn("You're opted to skip deleting the DAG entries!!!")
+        logging.warning("You're opted to skip deleting the DAG entries!!!")
 
     logging.info("Finished Running Clear Process")
 

--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -1,5 +1,7 @@
 """
-A maintenance workflow that you can deploy into Airflow to periodically clean out the DagRun, TaskInstance, Log, XCom, Job DB and SlaMiss entries to avoid having too much data in your Airflow MetaStore.
+A maintenance workflow that you can deploy into Airflow to periodically clean
+out the DagRun, TaskInstance, Log, XCom, Job DB and SlaMiss entries to avoid
+having too much data in your Airflow MetaStore.
 
 airflow trigger_dag --conf '{"maxDBEntryAgeInDays":30}' airflow-db-cleanup
 
@@ -27,7 +29,7 @@ except ImportError:
 
 DAG_ID = os.path.basename(__file__).replace(".pyc", "").replace(".py", "")  # airflow-db-cleanup
 START_DATE = now() - timedelta(minutes=1)
-SCHEDULE_INTERVAL = "@daily"            # How often to Run. @daily - Once a day at Midnight (UTC)
+SCHEDULE_INTERVAL = timedelta(days=1)   # How often to Run. @daily - Once a day at Midnight (UTC)
 DAG_OWNER_NAME = "operations"           # Who is listed as the owner of this DAG in the Airflow Web Server
 ALERT_EMAIL_ADDRESSES = []              # List of email address to send email alerts to if this job fails
 DEFAULT_MAX_DB_ENTRY_AGE_IN_DAYS = int(Variable.get("max_db_entry_age_in_days", 30)) # Length to retain the log files if not already provided in the conf. If this is set to 30, the job will remove those files that are 30 days old or older.
@@ -47,7 +49,7 @@ session = settings.Session()
 default_args = {
     'owner': DAG_OWNER_NAME,
     'email': ALERT_EMAIL_ADDRESSES,
-    'email_on_failure': True,
+    'email_on_failure': False,
     'email_on_retry': False,
     'start_date': START_DATE,
     'retries': 1,
@@ -139,7 +141,7 @@ def cleanup_function(**context):
         session.commit()
         logging.info("Finished Performing Delete")
     else:
-        logging.warn("You're opted to skip deleting the db entries!!!")
+        logging.warning("You're opted to skip deleting the db entries!!!")
 
     logging.info("Finished Running Cleanup Process")
 

--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -1,6 +1,9 @@
 """
-A maintenance workflow that you can deploy into Airflow to periodically clean out the task logs to avoid those getting too big.
+A maintenance workflow that you can deploy into Airflow to periodically clean
+out the task logs to avoid those getting too big.
+
 airflow trigger_dag --conf '{"maxLogAgeInDays":30}' airflow-log-cleanup
+
 --conf options:
     maxLogAgeInDays:<INT> - Optional
 """
@@ -20,12 +23,12 @@ except ImportError:
 DAG_ID = os.path.basename(__file__).replace(".pyc", "").replace(".py", "")  # airflow-log-cleanup
 START_DATE = now() - timedelta(minutes=1)
 BASE_LOG_FOLDER = conf.get("core", "BASE_LOG_FOLDER")
-SCHEDULE_INTERVAL = "@daily"        # How often to Run. @daily - Once a day at Midnight
-DAG_OWNER_NAME = "operations"       # Who is listed as the owner of this DAG in the Airflow Web Server
-ALERT_EMAIL_ADDRESSES = []          # List of email address to send email alerts to if this job fails
+SCHEDULE_INTERVAL = timedelta(days=1)  # How often to Run. @daily - Once a day at Midnight
+DAG_OWNER_NAME = "operations"          # Who is listed as the owner of this DAG in the Airflow Web Server
+ALERT_EMAIL_ADDRESSES = []             # List of email address to send email alerts to if this job fails
 DEFAULT_MAX_LOG_AGE_IN_DAYS = Variable.get("max_log_age_in_days", 30)  # Length to retain the log files if not already provided in the conf. If this is set to 30, the job will remove those files that are 30 days old or older
-ENABLE_DELETE = True                # Whether the job should delete the logs or not. Included if you want to temporarily avoid deleting the logs
-NUMBER_OF_WORKERS = 1               # The number of worker nodes you have in Airflow. Will attempt to run this process for however many workers there are so that each worker gets its logs cleared.
+ENABLE_DELETE = True                   # Whether the job should delete the logs or not. Included if you want to temporarily avoid deleting the logs
+NUMBER_OF_WORKERS = 1                  # The number of worker nodes you have in Airflow. Will attempt to run this process for however many workers there are so that each worker gets its logs cleared.
 DIRECTORIES_TO_DELETE = [BASE_LOG_FOLDER]
 ENABLE_DELETE_CHILD_LOG = Variable.get("enable_delete_child_log", "False")
 logging.info("ENABLE_DELETE_CHILD_LOG  " + ENABLE_DELETE_CHILD_LOG)


### PR DESCRIPTION
Currently these DAGs need to be triggered manually in order to start.

- Use `timedelta` for `SCHEDULE_INTERVAL` to trigger DAGs on startup
- Replace `logging.info` with `DEBUG` strings with `logging.debug`
- Replace `logging.warn` (now deprecated) with `logging.warning`
- Disable automatic emailing on task failure