### PR TITLE
Fix start time in DAGs

### DIFF
--- a/clear-missing-dags/airflow-clear-missing-dags.py
+++ b/clear-missing-dags/airflow-clear-missing-dags.py
@@ -4,19 +4,20 @@ out entries in the DAG table of which there is no longer a corresponding Python
 File for it. This ensures that the DAG table doesn't have needless items in it
 and that the Airflow Web Server displays only those available DAGs.
 """
-from datetime import datetime, timedelta
 import os
-import os.path
 import socket
 import logging
+from datetime import timedelta
 
 from airflow.models import DAG, DagModel
 from airflow.operators.python_operator import PythonOperator
+from airflow.utils import timezone
 from airflow import settings
 
+
 DAG_ID = os.path.basename(__file__).replace(".pyc", "").replace(".py", "")  # airflow-clear-missing-dags
-START_DATE = datetime.now() - timedelta(minutes=1)
 SCHEDULE_INTERVAL = timedelta(days=1)  # How often to Run. @daily - Once a day at Midnight
+START_DATE = timezone.utcnow().replace(second=0, microsecond=0) - SCHEDULE_INTERVAL
 DAG_OWNER_NAME = "operations"          # Who is listed as the owner of this DAG in the Airflow Web Server
 ALERT_EMAIL_ADDRESSES = []             # List of email address to send email alerts to if this job fails
 ENABLE_DELETE = True                   # Whether the job should delete the logs or not. Included if you want to temporarily avoid deleting the logs

--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -10,20 +10,16 @@ airflow trigger_dag --conf '{"maxLogAgeInDays":30}' airflow-log-cleanup
 from airflow.models import DAG, Variable
 from airflow.configuration import conf
 from airflow.operators.bash_operator import BashOperator
-from datetime import datetime, timedelta
+from airflow.utils import timezone
+from datetime import timedelta
 import os
 import logging
 
-try:
-    from airflow.utils import timezone  # airflow.utils.timezone is available from v1.10 onwards
-    now = timezone.utcnow
-except ImportError:
-    now = datetime.utcnow
 
 DAG_ID = os.path.basename(__file__).replace(".pyc", "").replace(".py", "")  # airflow-log-cleanup
-START_DATE = now() - timedelta(minutes=1)
-BASE_LOG_FOLDER = conf.get("core", "BASE_LOG_FOLDER")
 SCHEDULE_INTERVAL = timedelta(days=1)  # How often to Run. @daily - Once a day at Midnight
+START_DATE = timezone.utcnow().replace(second=0, microsecond=0) - SCHEDULE_INTERVAL
+BASE_LOG_FOLDER = conf.get("core", "BASE_LOG_FOLDER")
 DAG_OWNER_NAME = "operations"          # Who is listed as the owner of this DAG in the Airflow Web Server
 ALERT_EMAIL_ADDRESSES = []             # List of email address to send email alerts to if this job fails
 DEFAULT_MAX_LOG_AGE_IN_DAYS = Variable.get("max_log_age_in_days", 30)  # Length to retain the log files if not already provided in the conf. If this is set to 30, the job will remove those files that are 30 days old or older

--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -7,13 +7,14 @@ airflow trigger_dag --conf '{"maxLogAgeInDays":30}' airflow-log-cleanup
 --conf options:
     maxLogAgeInDays:<INT> - Optional
 """
+import os
+import logging
+from datetime import timedelta
+
 from airflow.models import DAG, Variable
 from airflow.configuration import conf
 from airflow.operators.bash_operator import BashOperator
 from airflow.utils import timezone
-from datetime import timedelta
-import os
-import logging
 
 
 DAG_ID = os.path.basename(__file__).replace(".pyc", "").replace(".py", "")  # airflow-log-cleanup


### PR DESCRIPTION
Despite previous changes, it appears that Airflow will not automatically run DAGs on start up unless  `START_TIME = current_time - SCHEDULE_INTERVAL`. This PR updates the `START_TIME` in each DAG to use this formula. 